### PR TITLE
chore(api): remove unneeded fields from start upload chunk api

### DIFF
--- a/apps/sql_data/apiviews.py
+++ b/apps/sql_data/apiviews.py
@@ -118,7 +118,6 @@ class SQLUploadMetadataViewSet(AuditBaseViewSet, AbstractEventPublisher):
     def start_chunk_upload(self, request: Request, pk) -> Response:
         """Start a new chunk upload."""
         self.check_object_permissions(request, request.user)
-        request.data["upload_metadata"] = str(pk)
         serializer: NewSQLUploadChunkSerializer = self.get_serializer(
             data=request.data
         )
@@ -127,6 +126,5 @@ class SQLUploadMetadataViewSet(AuditBaseViewSet, AbstractEventPublisher):
                 serializer.errors, status=status.HTTP_400_BAD_REQUEST
             )
 
-        serializer.save()
-
+        serializer.save(upload_metadata=self.get_object())
         return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/apps/sql_data/serializers.py
+++ b/apps/sql_data/serializers.py
@@ -12,7 +12,8 @@ from .models import (
 class NewSQLUploadChunkSerializer(AuditBaseSerializer):
     class Meta:
         model = SQLUploadChunk
-        fields = "__all__"
+        fields = ("chunk_index", "chunk_content", "upload_metadata")
+        read_only_fields = ("upload_metadata",)
 
 
 class SQLDatabaseSerializer(AuditBaseSerializer):


### PR DESCRIPTION
With this change, only the `chunk_index` and `chunk_content` fields are required when using the `start_upload_chunk` api making it more concise.