### PR TITLE
fix(db): database connection errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     # Service containers to run with `container-job`
     services:
       postgres:
-        image: postgis/postgis:13-3.1
+        image: postgis/postgis:15-3.3
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -45,7 +45,8 @@ DATABASES = {
         "HOST": env.str("POSTGRES_HOST"),
         "PORT": env.str("POSTGRES_PORT", None),
         "ENGINE": "django.contrib.gis.db.backends.postgis",
-        "ATOMIC_REQUESTS": True,
+        "ATOMIC_REQUESTS": False,
+        "CONN_HEALTH_CHECKS": True,
         "CONN_MAX_AGE": env.int("CONN_MAX_AGE", default=60),
     },
 }

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9.4
+python-3.11


### PR DESCRIPTION
This is an attempted fix for the databases connections errors at high load. Specifically, the error,  `OperationalError: could not connect to server: Connection refused`. The fix includes the following changes:
1. Performing health checks on existing connections on each request.
2. Disable Atomic requests on every view.
3. Increasing the maximum duration of a db connection to 3 minutes. (This is done using an environment variable on the deployment platforms).

This is a temporary fix and might have a minimal impact or not solve the problem. A proper fix might be implementing proper database connection pooling using tools such as [pgbouncer](https://www.pgbouncer.org).

Included are also other minor fixes and improvements.